### PR TITLE
Add root route to resolve 404 error on Render

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,14 @@
-from flask import Flask
+from flask import Flask, jsonify
 from flask_cors import CORS
 from routes import user_routes, generation_routes
 
 app = Flask(__name__)
 CORS(app)
+
+# New root route
+@app.route("/", methods=["GET"])
+def root():
+    return jsonify({"message": "Welcome to the API"}), 200
 
 app.register_blueprint(user_routes.bp)
 app.register_blueprint(generation_routes.bp)


### PR DESCRIPTION
I added a GET route for the root path (/) in `app.py`. This route returns a JSON response `{"message": "Welcome to the API"}`. This addresses the issue where deployments on Render would return a 404 error for the base URL because no root path was defined.